### PR TITLE
Fix compiling on Windows + README QoL improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker run -p 3000:3000 step-daddy-live-hd
 2. Clone the repository and navigate into the project directory:
    ```bash
    git clone https://github.com/gookie-dev/StepDaddyLiveHD
-   cd step-daddy-live-hd
+   cd StepDaddyLiveHD
    ```
 3. Create and activate a virtual environment:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ curl-cffi==0.11.4
 httpx[http2]==0.28.1
 python-dateutil==2.9.0
 fastapi==0.116.1
+tzdata==2025.2


### PR DESCRIPTION
This PR does two things:
  - Fixes step 2 of the manual installation docs to use the correct repo name for easier copy-pasting
  - Adds `tzdata` to `requirements.txt` to fix an issue when deploying on Windows (and apparently some Linux distros) where the OS doesn't include the timezone files required for the /schedule page to build thus resulting in it crashing with an error

I've tested building with these changes and it seems to be ok